### PR TITLE
Fix Compatibility With React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "librestapi",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "Light framework for defining javascript interfaces for REST based web services.",
     "main": "dist/index.js",
     "scripts": {
@@ -47,13 +47,15 @@
 	"intern": "^3.2.3",
 	"json-server": "^0.8.14",
 	"webpack": "^1.13.1",
-	"xmlhttprequest": "^1.8.0"
+	"xmlhttprequest": "^1.8.0",
+	"whatwg-fetch": "^1.0.0"
+    },
+    "peerDependencies": {
+	"fetch": "^1.1.0"
     },
     "dependencies": {
 	"es6-promise": "^3.2.1",
-	"node-fetch": "^1.5.3",
 	"node.extend": "^1.1.5",
-	"querystring": "^0.2.0",
-	"whatwg-fetch": "^1.0.0"
+	"querystring": "^0.2.0"
     }
 }

--- a/src/app/compat/fetch.js
+++ b/src/app/compat/fetch.js
@@ -1,6 +1,10 @@
-import fetchNode from 'node-fetch';
+let fetchCompatible = undefined;
+try {
+    fetchCompatible = require('fetch');
 
-let fetchCompatible = (
-    'undefined' === typeof fetch ? fetchNode : fetch
-);
+} catch (e) {
+    // Fetch not installed try to use native.
+    fetchCompatible = fetch;
+}
+
 export default fetchCompatible;


### PR DESCRIPTION
- Changed how check for fetch library is handled. should use native fetch if available.
- Moved fetch from dependencies to peerDependencies.
- Updated version to 0.3.3.
