### PR TITLE
Adjust Logic To Avoid Try/Catch For React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "librestapi",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "Light framework for defining javascript interfaces for REST based web services.",
     "main": "dist/index.js",
     "scripts": {

--- a/src/app/compat/fetch.js
+++ b/src/app/compat/fetch.js
@@ -1,10 +1,11 @@
 let fetchCompatible = undefined;
-try {
+
+if ('undefined' === typeof fetch) {
     fetchCompatible = require('fetch');
 
-} catch (e) {
-    // Fetch not installed try to use native.
+} else {
     fetchCompatible = fetch;
-}
+
+};
 
 export default fetchCompatible;

--- a/tests/unit/client.js
+++ b/tests/unit/client.js
@@ -1,6 +1,5 @@
 define(function (require) {
     var registerSuite = require('intern!object');
-    var URLSearchParams = require('intern/dojo/node!urlsearchparams').URLSearchParams;
     var querystring = require('intern/dojo/node!querystring');
     var assert = require('intern/chai!assert');
 


### PR DESCRIPTION
- For some reason react-native still gives Red Screen of Death when a require call fails inside of a try/catch. I adjusted the compatibilty import of fetch library to avoid using try/catch.
- Removed reference to library that is no longer used in tests.
- Updated to version 0.3.4.
