### PR TITLE
Add Support for "application/json" Content-Type

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,10 @@
 	"json-server": "^0.8.14",
 	"webpack": "^1.13.1",
 	"xmlhttprequest": "^1.8.0",
-	"whatwg-fetch": "^1.0.0"
-    },
-    "peerDependencies": {
-	"fetch": "^1.1.0"
+	"whatwg-fetch": "^1.0.0",
+	"es6-promise": "^3.2.1"
     },
     "dependencies": {
-	"es6-promise": "^3.2.1",
 	"node.extend": "^1.1.5",
 	"querystring": "^0.2.0"
     }

--- a/src/app/client.js
+++ b/src/app/client.js
@@ -83,8 +83,34 @@ class Client {
             options.body = undefined;
 
         } else {
-            options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-            options.body = querystring.stringify(options.body);
+            let contentType = options.headers['Content-Type'];
+            if ('undefined' === typeof contentType) {
+                contentType = this.options.contentType;
+
+            }
+            
+            if (
+                contentType == 'json' ||
+                contentType == 'application/json'
+            ) {
+                options.headers['Content-Type'] = 'application/json';
+                options.body = JSON.stringify(options.body);
+
+            } else if (
+                contentType == 'formdata' ||
+                contentType == 'application/x-www-form-urlencoded'
+            ) {
+                options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                options.body = querystring.stringify(options.body)
+
+            } else {
+                throw [
+                    'The Content-Type',
+                    contentType,
+                    'is not supported by this client.'
+                ].join(' ');
+
+            }
 
         }
 

--- a/src/app/compat/fetch.js
+++ b/src/app/compat/fetch.js
@@ -1,7 +1,7 @@
 let fetchCompatible = undefined;
 
 if ('undefined' === typeof fetch) {
-    fetchCompatible = require('fetch');
+    fetchCompatible = require('whatwg-fetch');
 
 } else {
     fetchCompatible = fetch;


### PR DESCRIPTION
- Added a configuration option for posting in JSON instead of in formdata.
- Changed logic to allow forcing a Content-Type by passing in headers to the request method.
- Cleaned up dependencies.
