### PR TITLE
Replace isomorphic-fetch with portable-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librestapi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Light framework for defining javascript interfaces for REST based web services.",
   "main": "dist/index.js",
   "scripts": {
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "es6-promise": "^4.1.1",
-    "isomorphic-fetch": "^2.2.1",
     "node.extend": "^1.1.5",
+    "portable-fetch": "^2.3.0",
     "querystring": "^0.2.0"
   }
 }


### PR DESCRIPTION
* isomorphic-fetch doesn't work with react-native so I forked it and fixed it and now it is a dependency of this project.
* Incremented patch version to 2.0.1