### PR TITLE
Replace es6-promise with promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "es6-promise": "^4.1.1",
     "node.extend": "^1.1.5",
     "portable-fetch": "^2.3.0",
+    "promise": "^8.0.0",
     "querystring": "^0.2.0"
   }
 }

--- a/src/app/client.js
+++ b/src/app/client.js
@@ -2,8 +2,7 @@ import querystring from 'querystring';
 import extend from 'node.extend';
 
 import 'portable-fetch';
-import Promise from 'es6-promise';
-Promise.polyfill();
+import Promise from 'promise';
 
 
 class Client {


### PR DESCRIPTION
* The polyfill we were using doesn't support all the extension methods that are becoming more popular. To increase portability we are using promise (the same promise polyfill used by react-native)