### PR TITLE
Make Git User Matching as Push Default

### DIFF
--- a/jenkins/scripts/publish.sh
+++ b/jenkins/scripts/publish.sh
@@ -10,6 +10,7 @@ echo ${1} > ~/.npmrc
 
     git config --global user.email "seth@knotis.com"
     git config --global user.name "Jenkins Bot"
+    git config --global push.default matching
 
     rm -rf ./node_modules
     npm install


### PR DESCRIPTION
* Never seen this message before but aparently you need to define the behavior of push.default now. I set this to "matching" as this is the original behavior.