### PR TITLE
Move Pushing and Tagging Version to After Publish

### DIFF
--- a/jenkins/scripts/publish.sh
+++ b/jenkins/scripts/publish.sh
@@ -16,9 +16,12 @@ echo ${1} > ~/.npmrc
     npm install
 
     VERSION=$(npm version patch)
-    git push
-    git tag -a ${VERSION} -m "Published Version: ${VERSION}"
-
     npm publish
 
+    git push
+
+    git tag --delete ${VERSION}
+    git tag -a ${VERSION} -m "Published Version: ${VERSION}"
+    git push origin ${VERSION}
+    
 )


### PR DESCRIPTION
* If publish fails we end up with bad tags so I moved the pushing and tagging to after the publish command.