### PR TITLE
Revert Changes to Publish Script

### DIFF
--- a/jenkins/scripts/publish.sh
+++ b/jenkins/scripts/publish.sh
@@ -10,18 +10,16 @@ echo ${1} > ~/.npmrc
 
     git config --global user.email "seth@knotis.com"
     git config --global user.name "Jenkins Bot"
-    git config --global push.default matching
+    git config --global push.default simple
 
     rm -rf ./node_modules
     npm install
 
     VERSION=$(npm version patch)
-    npm publish
-
     git push
-
-    git tag --delete ${VERSION}
     git tag -a ${VERSION} -m "Published Version: ${VERSION}"
     git push origin ${VERSION}
+
+    npm publish
     
 )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librestapi",
-  "version": "2.1.0",
+  "version": "2.4.1",
   "description": "Light framework for defining javascript interfaces for REST based web services.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
* Reverting changes to publish script. The version should be pushed before publish to appropriately handle concurrent publication steps.